### PR TITLE
Fix dependencies: ZF 2.0.* instead of self.version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-http": "self.version",
-        "zendframework/zend-uri": "self.version"
+        "zendframework/zend-http": "2.0.*",
+        "zendframework/zend-uri": "2.0.*"
     }
 }


### PR DESCRIPTION
ZF2 is at version 2.0.2 but ZendRest is still at 2.0.0. Using "self.version" in the dependencies prevents me from installing ZF 2.0.2.
