### PR TITLE
fix RestClient::restGet PHPDOC return type

### DIFF
--- a/library/ZendRest/Client/RestClient.php
+++ b/library/ZendRest/Client/RestClient.php
@@ -142,7 +142,7 @@ class RestClient
      *
      * @param string $path
      * @param array  $query Array of GET parameters
-     * @return Zend\Http\Response
+     * @return \Zend\Http\Response
      */
     public function restGet($path, array $query = null)
     {


### PR DESCRIPTION
namespace not prefixed
